### PR TITLE
Alternative Hover Mode w/ ascend/descend

### DIFF
--- a/src/main/java/net/fxnt/fxntstorage/backpack/upgrade/jetpack/JetpackHandler.java
+++ b/src/main/java/net/fxnt/fxntstorage/backpack/upgrade/jetpack/JetpackHandler.java
@@ -79,8 +79,9 @@ public class JetpackHandler {
     private int missedPackets = 0;
 
     private boolean cleanupNeeded = false;
-
     private IBackpackContainer itemHandler;
+    private int consecutiveAirTicks = 0;
+    private boolean receivedFlyingPacketThisAirSession = false;
 
     public JetpackHandler(Player player) {
         this.player = player;
@@ -93,8 +94,16 @@ public class JetpackHandler {
         if (player.isPassenger()) {
             isJumping = false;
             endHovering(false);
+            receivedFlyingPacketThisAirSession = false;
             fadeOutVisualAirOverlay();
             return;
+        }
+
+        if (player.onGround()) {
+            consecutiveAirTicks = 0;
+            receivedFlyingPacketThisAirSession = false;
+        } else {
+            consecutiveAirTicks++;
         }
 
         if (player.level().isClientSide) {
@@ -107,7 +116,7 @@ public class JetpackHandler {
     private void executeClient() {
         updatePredictedFuel();
 
-        if (isHovering && wasTeleported()) {
+        if (isHovering && receivedFlyingPacketThisAirSession && consecutiveAirTicks >= 2) {
             hoverHeight = player.getY();
         }
 
@@ -117,20 +126,10 @@ public class JetpackHandler {
                 return;
             }
 
-            player.setNoGravity(true);
+            player.setNoGravity(!player.onGround());
             player.resetFallDistance();
 
-            if (player.isShiftKeyDown()) {
-                startHovering(true);
-            } else if (isHovering) {
-                endHovering(true);
-            }
-
             updateClientMovementWithInterpolation();
-
-            if (player.onGround() && isHovering) {
-                endHovering(true);
-            }
 
             if (!player.isInWater() && !player.isInLava()) {
                 handleThrustSound();
@@ -140,16 +139,16 @@ public class JetpackHandler {
             playedSoundThisJump = !player.onGround();
 
             if (isHovering) {
-                if (player.onGround()) {
-                    endHovering(true);
-                }
-
                 if (predictedFuelRemaining <= 0) {
                     endHovering(false);
                     return;
                 }
 
-                updateClientMovementWithInterpolation();
+                if (receivedFlyingPacketThisAirSession && consecutiveAirTicks >= 2) {
+                    updateClientMovementWithInterpolation();
+                } else {
+                    player.setNoGravity(false);
+                }
             } else {
                 player.setNoGravity(false);
                 fadeOutVisualAirOverlay();
@@ -164,7 +163,7 @@ public class JetpackHandler {
 
         jetPackFuelRemaining = (float) calculateJetPackFuel(player);
 
-        if ((isJumping || isHovering) && jetPackFuelRemaining > 0) {
+        if (receivedFlyingPacketThisAirSession && (isJumping || isHovering) && jetPackFuelRemaining > 0) {
             player.setNoGravity(true);
             depleteJetPackFuel(player);
             validatePlayerMovement();
@@ -319,11 +318,8 @@ public class JetpackHandler {
     }
 
     public void toggleHover() {
-        if (player.onGround()) {
-            endHovering(false);
-            return;
-        }
         if (!isHovering) {
+            if (player.onGround()) return;
             startHovering(true);
         } else {
             player.setNoGravity(false);
@@ -564,15 +560,31 @@ public class JetpackHandler {
     }
 
     private double calculateVerticalHoveringSpeed(double targetHeight) {
-        ItemStack backpack = BackpackHelper.getEquippedBackpackStack(player);
-        UpgradeDataManager manager = UpgradeDataManager.loadFromItem(backpack);
-        boolean bobbingEnabled = manager.getSetting(UpgradeDataSync.Field.JETPACK_BOBBING, true);
+        double distanceToGround = getDistanceToGround(player);
+
+        if (isJumping) {
+            if (distanceToGround > MAX_ALLOWED_HEIGHT) {
+                return -0.1;
+            }
+            return 0.42;
+        }
+        if (player.isShiftKeyDown()) {
+            return -0.3;
+        }
 
         double currentY = player.getY();
         double yDifference = targetHeight - currentY;
 
         double adjustmentForce = yDifference * 0.3;
         double newYVelocity = player.getDeltaMovement().y * 0.8 + adjustmentForce;
+
+        if (distanceToGround > MAX_ALLOWED_HEIGHT) {
+            newYVelocity = Math.min(newYVelocity, -0.1);
+        }
+
+        ItemStack backpack = BackpackHelper.getEquippedBackpackStack(player);
+        UpgradeDataManager manager = UpgradeDataManager.loadFromItem(backpack);
+        boolean bobbingEnabled = manager.getSetting(UpgradeDataSync.Field.JETPACK_BOBBING, true);
 
         if (bobbingEnabled && player.level().isClientSide()) {
             float time = player.level().getGameTime() + Minecraft.getInstance().getTimer().getGameTimeDeltaPartialTick(false);
@@ -693,9 +705,11 @@ public class JetpackHandler {
         this.left = left;
     }
 
-    public void processPlayerFlyingPacket(boolean flying, boolean hovering) {
+    public void processPlayerFlyingPacket(boolean flying) {
         this.isJumping = flying;
-        this.isHovering = hovering;
+        if (flying) {
+            this.receivedFlyingPacketThisAirSession = true;
+        }
     }
 
     public void flyingOnKeyPress() {

--- a/src/main/java/net/fxnt/fxntstorage/backpack/upgrade/jetpack/JetpackHandler.java
+++ b/src/main/java/net/fxnt/fxntstorage/backpack/upgrade/jetpack/JetpackHandler.java
@@ -714,6 +714,7 @@ public class JetpackHandler {
 
     public void flyingOnKeyPress() {
         this.isJumping = true;
+        this.receivedFlyingPacketThisAirSession = true;
     }
 
     public void flyingOnKeyRelease() {

--- a/src/main/java/net/fxnt/fxntstorage/backpack/upgrade/jetpack/JetpackHandler.java
+++ b/src/main/java/net/fxnt/fxntstorage/backpack/upgrade/jetpack/JetpackHandler.java
@@ -735,5 +735,6 @@ public class JetpackHandler {
         lastValidVelocity = Vec3.ZERO;
         predictedFuelRemaining = 0;
         lastFuelSync = 0;
+        receivedFlyingPacketThisAirSession = false;
     }
 }

--- a/src/main/java/net/fxnt/fxntstorage/network/packet/JetpackFlyingPacket.java
+++ b/src/main/java/net/fxnt/fxntstorage/network/packet/JetpackFlyingPacket.java
@@ -10,13 +10,12 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 
-public record JetpackFlyingPacket(boolean flying, boolean hovering) implements CustomPacketPayload {
+public record JetpackFlyingPacket(boolean flying) implements CustomPacketPayload {
     public static final Type<JetpackFlyingPacket> TYPE =
             new Type<>(ResourceLocation.fromNamespaceAndPath(FXNTStorage.MOD_ID, "jetpack_flying"));
 
     public static final StreamCodec<FriendlyByteBuf, JetpackFlyingPacket> STREAM_CODEC = StreamCodec.composite(
             ByteBufCodecs.BOOL, JetpackFlyingPacket::flying,
-            ByteBufCodecs.BOOL, JetpackFlyingPacket::hovering,
             JetpackFlyingPacket::new
     );
 
@@ -28,7 +27,7 @@ public record JetpackFlyingPacket(boolean flying, boolean hovering) implements C
     public void handle(final IPayloadContext context) {
         context.enqueueWork(() -> {
             if (context.player() instanceof ServerPlayer player) {
-                JetpackManager.getJetpackHandler(player).processPlayerFlyingPacket(flying(), hovering());
+                JetpackManager.getJetpackHandler(player).processPlayerFlyingPacket(flying());
             }
         });
     }

--- a/src/main/java/net/fxnt/fxntstorage/util/KeybindHandler.java
+++ b/src/main/java/net/fxnt/fxntstorage/util/KeybindHandler.java
@@ -39,11 +39,19 @@ public class KeybindHandler {
     public static final KeyMapping FLY_JETPACK = new KeyMapping("hotKey.fxntstorage.fly_jetpack", GLFW.GLFW_KEY_SPACE, KEY_CATEGORY_FXNTSTORAGE);
 
     private static boolean flykeyWasDown = false;
+    private static boolean flyModeActive = false;
+    private static long lastFlyKeyPressTime = 0;
+    private static final long DOUBLE_TAP_THRESHOLD = 300;
     private static boolean minekeyWasDown = false;
     private static boolean minePreviewActive = false;
 
     public static void resetFlyKeyState() {
         flykeyWasDown = false;
+        flyModeActive = false;
+    }
+
+    public static boolean isFlyModeActive() {
+        return flyModeActive;
     }
 
     @EventBusSubscriber(modid = FXNTStorage.MOD_ID, value = Dist.CLIENT)
@@ -104,14 +112,31 @@ public class KeybindHandler {
             }
             minekeyWasDown = minekeyIsDown;
 
-            // === FLY JETPACK KEY ===
+            // === FLY JETPACK KEY (double-tap to activate) ===
             boolean flykeyIsDown = FLY_JETPACK.isDown();
-            boolean shiftIsDown = player.isShiftKeyDown();
 
-            if (flykeyIsDown != flykeyWasDown && isSurvival && isWearingBackpack
+            if (flykeyIsDown && !flykeyWasDown) {
+                long now = System.currentTimeMillis();
+                if (now - lastFlyKeyPressTime < DOUBLE_TAP_THRESHOLD) {
+                    if (!flyModeActive) {
+                        flyModeActive = true;
+                    }
+                }
+                lastFlyKeyPressTime = now;
+            }
+
+            if (flyModeActive && player.onGround()) {
+                flyModeActive = false;
+                PacketDistributor.sendToServer(new JetpackFlyingPacket(false));
+                JetpackManager.getJetpackHandler(player).processPlayerFlyingPacket(false);
+            }
+
+            if (flyModeActive && isSurvival && isWearingBackpack
                     && UpgradeHelper.hasActiveUpgrade(backpackContainer.getItemHandler(), UpgradeType.FLIGHT)) {
-                PacketDistributor.sendToServer(new JetpackFlyingPacket(flykeyIsDown, shiftIsDown));
-                JetpackManager.getJetpackHandler(player).processPlayerFlyingPacket(flykeyIsDown, shiftIsDown);
+                if (flykeyIsDown != flykeyWasDown) {
+                    PacketDistributor.sendToServer(new JetpackFlyingPacket(flykeyIsDown));
+                    JetpackManager.getJetpackHandler(player).processPlayerFlyingPacket(flykeyIsDown);
+                }
             }
 
             flykeyWasDown = flykeyIsDown;

--- a/src/main/java/net/fxnt/fxntstorage/util/KeybindHandler.java
+++ b/src/main/java/net/fxnt/fxntstorage/util/KeybindHandler.java
@@ -39,19 +39,11 @@ public class KeybindHandler {
     public static final KeyMapping FLY_JETPACK = new KeyMapping("hotKey.fxntstorage.fly_jetpack", GLFW.GLFW_KEY_SPACE, KEY_CATEGORY_FXNTSTORAGE);
 
     private static boolean flykeyWasDown = false;
-    private static boolean flyModeActive = false;
-    private static long lastFlyKeyPressTime = 0;
-    private static final long DOUBLE_TAP_THRESHOLD = 300;
     private static boolean minekeyWasDown = false;
     private static boolean minePreviewActive = false;
 
     public static void resetFlyKeyState() {
         flykeyWasDown = false;
-        flyModeActive = false;
-    }
-
-    public static boolean isFlyModeActive() {
-        return flyModeActive;
     }
 
     @EventBusSubscriber(modid = FXNTStorage.MOD_ID, value = Dist.CLIENT)
@@ -112,26 +104,10 @@ public class KeybindHandler {
             }
             minekeyWasDown = minekeyIsDown;
 
-            // === FLY JETPACK KEY (double-tap to activate) ===
+            // === FLY JETPACK KEY (hold to fly) ===
             boolean flykeyIsDown = FLY_JETPACK.isDown();
 
-            if (flykeyIsDown && !flykeyWasDown) {
-                long now = System.currentTimeMillis();
-                if (now - lastFlyKeyPressTime < DOUBLE_TAP_THRESHOLD) {
-                    if (!flyModeActive) {
-                        flyModeActive = true;
-                    }
-                }
-                lastFlyKeyPressTime = now;
-            }
-
-            if (flyModeActive && player.onGround()) {
-                flyModeActive = false;
-                PacketDistributor.sendToServer(new JetpackFlyingPacket(false));
-                JetpackManager.getJetpackHandler(player).processPlayerFlyingPacket(false);
-            }
-
-            if (flyModeActive && isSurvival && isWearingBackpack
+            if (isSurvival && isWearingBackpack
                     && UpgradeHelper.hasActiveUpgrade(backpackContainer.getItemHandler(), UpgradeType.FLIGHT)) {
                 if (flykeyIsDown != flykeyWasDown) {
                     PacketDistributor.sendToServer(new JetpackFlyingPacket(flykeyIsDown));


### PR DESCRIPTION
I'll be honest, I don't like the default hover mode too much when it comes to building, it's a bit annoying having to keep your fingers on the hotkey. I feel like something that would let you ascend/descend in creative-like fashion is more intuitive and less difficult to use, which is how both Create Jetpack and Stuff and Additions do it (if I'm not mistaken). This is just a little annoyance of mine that I hope to be able to help with, I like the mod otherwise and appreciate a lot the work you do!

**I vibe coded this PR only as a proof of concept** so we could hopefully discuss and test it, feel free to reject if you don't like the idea at all, else I'll be more than glad to make a proper implementation. This is **NOT** meant to be merged in it's current state.

A major issue with this implementation is that hover would make you "float" when you are on the air, which is not great when you want to stay on the ground and jump. This could be solved with a separate "fly" hotkey (e.g Jetpack's "Toggle Engine" with G, "Hover" with H) or by starting fly on ground with something like double-tap (1).
Some further considerations are:

- (1) How do we handle turning fly on/off? 
- Should this replace the current hover mode or be added as an "alternatve"?
- Should hover untoggle when you touch the ground?
- Does this require balancing? (e.g reducing max height)

Demonstration of alternative hovering:

[Screencast_20260612_203845.webm](https://github.com/user-attachments/assets/81815900-6af1-415a-bfa4-de177bba15a1)
